### PR TITLE
Tidy up GUI logic and implement slot predicates

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketSlot.java
+++ b/src/main/java/dev/emi/trinkets/TrinketSlot.java
@@ -1,8 +1,20 @@
 package dev.emi.trinkets;
 
+import java.util.Optional;
+
+import com.mojang.datafixers.util.Function3;
+
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.Trinket.SlotReference;
+import net.fabricmc.fabric.api.util.TriState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
 
@@ -14,11 +26,13 @@ public class TrinketSlot extends Slot {
 	private SlotType type;
 	private boolean alwaysVisible;
 	private boolean baseType;
+	private int slotOffset;
 
-	public TrinketSlot(Inventory inventory, int index, int x, int y, SlotGroup group, SlotType type, boolean alwaysVisible, boolean baseType) {
+	public TrinketSlot(Inventory inventory, int index, int x, int y, SlotGroup group, SlotType type, int slotOffset, boolean alwaysVisible, boolean baseType) {
 		super(inventory, index, x, y);
 		this.group = group;
 		this.type = type;
+		this.slotOffset = slotOffset;
 		this.alwaysVisible = alwaysVisible;
 		this.baseType = baseType;
 	}
@@ -32,6 +46,45 @@ public class TrinketSlot extends Slot {
 
 	public Identifier getBackgroundIdentifier() {
 		return type.getIcon();
+	}
+
+	@Override
+	public boolean canInsert(ItemStack stack) {
+		LivingEntity entity = ((TrinketInventory) inventory).component.entity;
+		SlotReference reference = new SlotReference(type, slotOffset);
+		TriState state = TriState.DEFAULT;
+		for (Identifier id : type.getValidators()) {
+			Optional<Function3<ItemStack, SlotReference, LivingEntity, TriState>> function = TrinketsApi.getValidatorPredicator(id);
+			if (function.isPresent()) {
+				state = function.get().apply(stack, reference, entity);
+			}
+			if (state != TriState.DEFAULT) {
+				break;
+			}
+		}
+		if (state == TriState.DEFAULT) {
+			state = TrinketsApi.getValidatorPredicator(new Identifier("trinkets", "tag")).get().apply(stack, reference, entity);
+		}
+		if (state.get()) {
+			Optional<Trinket> trinket = TrinketsApi.getTrinket(stack.getItem());
+			if (trinket.isPresent()) {
+				return trinket.get().canEquip(stack, reference, entity);
+			} else {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean canTakeItems(PlayerEntity player) {
+		ItemStack stack = this.getStack();
+		Optional<Trinket> trinket = TrinketsApi.getTrinket(stack.getItem());
+		if (trinket.isPresent()) {
+			return trinket.get().canUnequip(stack, new Trinket.SlotReference(type, slotOffset), player);
+		} else {
+			return true;
+		}
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,6 +1,7 @@
 package dev.emi.trinkets;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
+import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.data.SlotLoader;
@@ -9,8 +10,15 @@ import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,13 +32,35 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
-		/*TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket(){
+		TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket() {
 			
 			@Override
-			public void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
-				System.out.println(slot.slot.getName());
+			public boolean canEquip(ItemStack stack, SlotReference slot, LivingEntity entity) {
+				return true;
 			}
-		});*/
+		});
+	}
+
+	public void registerDefaultPredicates() {
+		TrinketsApi.registerQuickMovePredicate(new Identifier(MOD_ID, "always"), (stack, slot, entity) -> {
+			return TriState.TRUE;
+		});
+		TrinketsApi.registerQuickMovePredicate(new Identifier(MOD_ID, "never"), (stack, slot, entity) -> {
+			return TriState.FALSE;
+		});
+		TrinketsApi.registerValidatorPredicate(new Identifier(MOD_ID, "tag"), (stack, slot, entity) -> {
+			Tag<Item> tag = entity.world.getTagManager().getItems().getTagOrEmpty(new Identifier("trinkets", slot.slot.getGroup() + "/" + slot.slot.getName()));
+			if (tag.contains(stack.getItem())) {
+				return TriState.TRUE;
+			}
+			return TriState.DEFAULT;
+		});
+		TrinketsApi.registerValidatorPredicate(new Identifier(MOD_ID, "all"), (stack, slot, entity) -> {
+			return TriState.TRUE;
+		});
+		TrinketsApi.registerValidatorPredicate(new Identifier(MOD_ID, "none"), (stack, slot, entity) -> {
+			return TriState.FALSE;
+		});
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/SlotType.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotType.java
@@ -12,19 +12,19 @@ public class SlotType {
 	private final int amount;
 	private final int locked;
 	private final Identifier icon;
-	private final boolean transferable;
+	private final Set<Identifier> quickMove;
 	private final Set<Identifier> validators;
 	private final DropRule dropRule;
 
 	public SlotType(String group, String name, int order, int amount, int locked, Identifier icon,
-			boolean transferable, Set<Identifier> validators, DropRule dropRule) {
+			Set<Identifier> quickMove, Set<Identifier> validators, DropRule dropRule) {
 		this.group = group;
 		this.name = name;
 		this.order = order;
 		this.amount = amount;
 		this.locked = locked;
 		this.icon = icon;
-		this.transferable = transferable;
+		this.quickMove = quickMove;
 		this.validators = validators;
 		this.dropRule = dropRule;
 	}
@@ -53,8 +53,8 @@ public class SlotType {
 		return icon;
 	}
 
-	public boolean isTransferable() {
-		return transferable;
+	public Set<Identifier> getQuickMove() {
+		return quickMove;
 	}
 
 	public Set<Identifier> getValidators() {

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,20 +1,30 @@
 package dev.emi.trinkets.api;
 
+import dev.emi.trinkets.api.Trinket.SlotReference;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.onyxstudios.cca.api.v3.component.ComponentKey;
 import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import com.mojang.datafixers.util.Function3;
+
+import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 
 public class TrinketsApi {
 
 	public static final ComponentKey<TrinketComponent> TRINKET_COMPONENT = ComponentRegistryV3.INSTANCE
 			.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
+	private static final Map<Identifier, Function3<ItemStack, SlotReference, LivingEntity, TriState>> QUICK_MOVE_PREDICATES
+			= new HashMap<Identifier, Function3<ItemStack, SlotReference, LivingEntity, TriState>>(); 
+	private static final Map<Identifier, Function3<ItemStack, SlotReference, LivingEntity, TriState>> VALIDATOR_PREDICATES
+			= new HashMap<Identifier, Function3<ItemStack, SlotReference, LivingEntity, TriState>>(); 
 
 	private static final Map<Item, Trinket> TRINKETS = new HashMap<Item, Trinket>();
 
@@ -36,5 +46,27 @@ public class TrinketsApi {
 
 	public static Map<String, SlotGroup> getEntitySlots(EntityType<?> type) {
 		return EntitySlotLoader.INSTANCE.getEntitySlots(type);
+	}
+
+	public static void registerQuickMovePredicate(Identifier id, Function3<ItemStack, SlotReference, LivingEntity, TriState> predicate) {
+		QUICK_MOVE_PREDICATES.put(id, predicate);
+	}
+
+	public static void registerValidatorPredicate(Identifier id, Function3<ItemStack, SlotReference, LivingEntity, TriState> predicate) {
+		VALIDATOR_PREDICATES.put(id, predicate);
+	}
+
+	public static Optional<Function3<ItemStack, SlotReference, LivingEntity, TriState>> getQuickMovePredicate(Identifier id) {
+		if (QUICK_MOVE_PREDICATES.containsKey(id)) {
+			return Optional.of(QUICK_MOVE_PREDICATES.get(id));
+		}
+		return Optional.empty();
+	}
+
+	public static Optional<Function3<ItemStack, SlotReference, LivingEntity, TriState>> getValidatorPredicator(Identifier id) {
+		if (VALIDATOR_PREDICATES.containsKey(id)) {
+			return Optional.of(VALIDATOR_PREDICATES.get(id));
+		}
+		return Optional.empty();
 	}
 }

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -116,14 +116,15 @@ public class SlotLoader extends SinglePreparationResourceReloadListener<Map<Stri
 		private int amount = 1;
 		private int locked = 0;
 		private String icon = "";
-		private boolean transferable = false;
+		private Set<String> quickMove = new HashSet<>();
 		private Set<String> validators = new HashSet<>();
 		private String dropRule = DropRule.DEFAULT.toString();
 
 		SlotType create(String group, String name) {
 			Identifier finalIcon = new Identifier(icon);
 			Set<Identifier> finalValidators = validators.stream().map(Identifier::new).collect(Collectors.toSet());
-			return new SlotType(group, name, order, amount, locked, finalIcon, transferable, finalValidators, DropRule.valueOf(dropRule));
+			Set<Identifier> finalQuickMove = validators.stream().map(Identifier::new).collect(Collectors.toSet());
+			return new SlotType(group, name, order, amount, locked, finalIcon, finalQuickMove, finalValidators, DropRule.valueOf(dropRule));
 		}
 
 		void read(JsonObject jsonObject) {
@@ -140,8 +141,18 @@ public class SlotLoader extends SinglePreparationResourceReloadListener<Map<Stri
 
 			icon = JsonHelper.getString(jsonObject, "icon", icon);
 
-			boolean jsonTransferable = JsonHelper.getBoolean(jsonObject, "transferable", transferable);
-			transferable = replace ? jsonTransferable : (transferable || jsonTransferable);
+			JsonArray jsonQuickMoves = JsonHelper.getArray(jsonObject, "quick_move", new JsonArray());
+
+			if (jsonQuickMoves != null) {
+
+				if (replace && jsonQuickMoves.size() > 0) {
+					quickMove.clear();
+				}
+
+				for (JsonElement jsonQuickMove : jsonQuickMoves) {
+					quickMove.add(jsonQuickMove.getAsString());
+				}
+			}
 
 			String jsonDropRule = JsonHelper.getString(jsonObject, "drop_rule", dropRule);
 

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -15,6 +15,7 @@ import dev.emi.trinkets.TrinketsClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -68,8 +69,9 @@ public abstract class HandledScreenMixin extends Screen {
 					info.setReturnValue(false);
 				}
 			} else {
-				//TODO vanilla slot
-				info.setReturnValue(false);
+				if (!(slot.inventory instanceof PlayerInventory) || slot.id != TrinketsClient.activeGroup.getSlotId()) {
+					info.setReturnValue(false);
+				}
 			}
 		}
 	}

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -9,7 +9,7 @@
 	],
 	"client": [
 		"InventoryScreenMixin",
-		"HandledScreenMixin"
+		"HandledScreenMixin",
 		"PlayerEntityRendererMixin"
 	],
 	"injectors": {


### PR DESCRIPTION
Lots of stuff in this one, some things we talked about

* GUI stuff is a bit more refined, slot location is calculated dynamically based on the actual positions of slots and places excess groups accordingly, still a bit to go here on the rendering side for when there are >3 non-vanilla slot groups
* Predicates are implemented, accessed through `TrinketsApi`, they provide a way for programmers to define a tristate predicate for 2 and potentially more actions (if needed) right now only validator predicates are used, quick move ones aren't because trinket slot quick moving hasn't been implemented yet
#### Some smaller things
* You can now access vanilla slots if the trinket slot group is based on top of it
* Trinket slots in inventory now entirely follow the rules for inserting and removing trinkets (events are not triggered as this will be updated with EAMs when they are implemented)