### PR TITLE
Trinket EAMs and shift clicking

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@ name=trinkets
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.16.2
-yarn_mappings=1.16.2+build.19
-loader_version=0.9.1+build.205
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+build.7
+loader_version=0.10.8
 
 mod_version = 3.0.0
 maven_group = dev.emi
 archives_base_name = trinkets
 
-fabric_version=0.18.0+build.397-1.16
+fabric_version=0.27.1+1.16

--- a/src/main/java/dev/emi/trinkets/TrinketFeatureRenderer.java
+++ b/src/main/java/dev/emi/trinkets/TrinketFeatureRenderer.java
@@ -24,8 +24,8 @@ public class TrinketFeatureRenderer extends FeatureRenderer<AbstractClientPlayer
 	}
 
 	@Override
-	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumer, int light, AbstractClientPlayerEntity player, float a, float b, float c, float d,
-			float headYaw, float headPitch) {
+	public void render(MatrixStack matrices, VertexConsumerProvider vertexConsumer, int light, AbstractClientPlayerEntity player, float limbAngle,
+			float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch) {
 		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
 			TrinketInventory inv = trinkets.getInventory();
 
@@ -33,10 +33,10 @@ public class TrinketFeatureRenderer extends FeatureRenderer<AbstractClientPlayer
 				ItemStack stack = inv.getStack(i);
 				Pair<SlotType, Integer> p = inv.posMap.get(i);
 				TrinketRendererRegistry.getRenderer(stack.getItem()).ifPresent(renderer -> {
-					matrixStack.push();
-					renderer.render(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), matrixStack, vertexConsumer, light, context.getModel(), player,
-							headYaw, headPitch);
-					matrixStack.pop();
+					matrices.push();
+					renderer.render(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), matrices, vertexConsumer, light, context.getModel(), player,
+							limbAngle, limbDistance, tickDelta, animationProgress, headYaw, headPitch);
+					matrices.pop();
 				});
 			}
 		});

--- a/src/main/java/dev/emi/trinkets/TrinketSlot.java
+++ b/src/main/java/dev/emi/trinkets/TrinketSlot.java
@@ -41,6 +41,9 @@ public class TrinketSlot extends Slot {
 		if (TrinketsClient.activeGroup == group) {
 			return baseType || TrinketsClient.activeType == type;
 		}
+		if (TrinketsClient.quickMoveGroup == group) {
+			return baseType || TrinketsClient.quickMoveType == type;
+		}
 		return false;
 	}
 

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -7,6 +7,9 @@ import net.fabricmc.api.ClientModInitializer;
 public class TrinketsClient implements ClientModInitializer {
 	public static SlotGroup activeGroup = null;
 	public static SlotType activeType = null; // TODO mostly unused
+	public static SlotGroup quickMoveGroup = null;
+	public static SlotType quickMoveType = null;
+	public static int quickMoveTimer = 0;
 
 	@Override
 	public void onInitializeClient() {

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -12,12 +12,20 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.attribute.EntityAttributeModifier.Operation;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
+
+import java.util.UUID;
+
+import com.google.common.collect.Multimap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,14 +37,18 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 
 	@Override
 	public void onInitialize() {
+		registerDefaultPredicates();
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
 		TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket() {
-			
+
 			@Override
-			public boolean canEquip(ItemStack stack, SlotReference slot, LivingEntity entity) {
-				return true;
+			public Multimap<EntityAttribute, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot,
+					LivingEntity entity, UUID uuid) {
+				Multimap<EntityAttribute, EntityAttributeModifier> map = Trinket.super.getModifiers(stack, slot, entity, uuid);
+				map.put(EntityAttributes.GENERIC_MAX_HEALTH, new EntityAttributeModifier(uuid, "Max health", 10.0d, Operation.ADDITION));
+				return map;
 			}
 		});
 	}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -1,14 +1,19 @@
 package dev.emi.trinkets.api;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.Trinket.SlotReference;
 import dev.onyxstudios.cca.api.v3.component.AutoSyncedComponent;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.util.Pair;
 
 public class LivingEntityTrinketComponent implements TrinketComponent, AutoSyncedComponent {
 
@@ -34,7 +39,8 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 					if (i >= entry.getKey().getAmount()) {
 						if (!stack.isEmpty()) {
 							// If amount is lowered between loads of the entity drop excess
-							TrinketsMain.LOGGER.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
+							TrinketsMain.LOGGER
+									.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
 							entity.dropStack(stack);
 						}
 					} else {
@@ -52,7 +58,8 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 					ItemStack stack = ItemStack.fromTag(c);
 					if (!stack.isEmpty()) {
 						// If slot is removed between loads of the entity drop items
-						TrinketsMain.LOGGER.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
+						TrinketsMain.LOGGER
+								.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
 						entity.dropStack(stack);
 					}
 				}
@@ -77,5 +84,28 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 	@Override
 	public TrinketInventory getInventory() {
 		return inventory;
+	}
+
+	@Override
+	public boolean isEquipped(Predicate<ItemStack> predicate) {
+		for (int i = 0; i < inventory.size(); i++) {
+			if (predicate.test(inventory.getStack(i))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public List<Pair<SlotReference, ItemStack>> getEquipped(Predicate<ItemStack> predicate) {
+		List<Pair<SlotReference, ItemStack>> list = new ArrayList<Pair<SlotReference, ItemStack>>();
+		for (int i = 0; i < inventory.size(); i++) {
+			ItemStack stack = inventory.getStack(i);
+			if (predicate.test(stack)) {
+				Pair<SlotType, Integer> pair = inventory.posMap.get(i);
+				list.add(new Pair<SlotReference, ItemStack>(new SlotReference(pair.getLeft(), pair.getRight()), stack));
+			}
+		}
+		return list;
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -3,6 +3,8 @@ package dev.emi.trinkets.api;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Optional;
+import java.util.UUID;
+
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttribute;
@@ -48,9 +50,10 @@ public interface Trinket {
 	/**
 	 * Returns the Entity Attribute Modifiers for a stack in a slot. Child implementations should
 	 * remain pure
+	 * @param uuid The UUID to use for creating attributes
 	 */
 	public default Multimap<EntityAttribute, EntityAttributeModifier> getModifiers(ItemStack stack,
-			SlotReference slot, LivingEntity entity) {
+			SlotReference slot, LivingEntity entity, UUID uuid) {
 		Multimap<EntityAttribute, EntityAttributeModifier> map = HashMultimap.create();
 		if (stack.hasTag() && stack.getTag().contains("TrinketAttributeModifiers", 9)) {
 			ListTag list = stack.getTag().getList("TrinketAttributeModifiers", 10);
@@ -85,7 +88,7 @@ public interface Trinket {
 
 	public static class SlotReference {
 		public SlotType slot;
-		public int index; 
+		public int index;
 
 		public SlotReference(SlotType slot, int index) {
 			this.slot = slot;

--- a/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
@@ -1,8 +1,27 @@
 package dev.emi.trinkets.api;
 
+import java.util.List;
+import java.util.function.Predicate;
+
+import dev.emi.trinkets.api.Trinket.SlotReference;
 import dev.onyxstudios.cca.api.v3.component.ComponentV3;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
 
 public interface TrinketComponent extends ComponentV3 {
 
 	public TrinketInventory getInventory();
+
+	public boolean isEquipped(Predicate<ItemStack> predicate);
+
+	public default boolean isEquipped(Item item) {
+		return isEquipped(stack -> stack.getItem() == item);
+	}
+
+	public List<Pair<SlotReference, ItemStack>> getEquipped(Predicate<ItemStack> predicate);
+
+	public default List<Pair<SlotReference, ItemStack>> getEquipped(Item item) {
+		return getEquipped(stack -> stack.getItem() == item);
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
+++ b/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
@@ -9,104 +9,105 @@ import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.item.ItemStack;
 
 public interface TrinketRenderer {
+	public static final float MAGIC_ROTATION = 180f / (float) Math.PI;
 
-	void render(ItemStack stack, Trinket.SlotReference slot, MatrixStack matrixStack, VertexConsumerProvider vertexConsumer, int light,
-			PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw, float headPitch);
+	void render(ItemStack stack, Trinket.SlotReference slot, MatrixStack matrices, VertexConsumerProvider vertexConsumer, int light,
+			PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float limbAngle, float limbDistance,
+			float tickDelta, float animationProgress, float headYaw, float headPitch);
 
-	// todo: Review these translation methods before release
 	/**
 	 * Translates the rendering context to the center of the player's face
 	 */
-	static void translateToFace(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw,
+	static void translateToFace(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw,
 			float headPitch) {
 
 		if (player.isInSwimmingPose() || player.isFallFlying()) {
-			matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.head.roll));
-			matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
-			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-45.0F));
+			matrices.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.head.roll));
+			matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
+			matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-45.0F));
 		} else {
 
 			if (player.isInSneakingPose() && !model.riding) {
-				matrixStack.translate(0.0F, 0.25F, 0.0F);
+				matrices.translate(0.0F, 0.25F, 0.0F);
 			}
-			matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
-			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(headPitch));
+			matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
+			matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(headPitch));
 		}
-		matrixStack.translate(0.0F, -0.25F, -0.3F);
+		matrices.translate(0.0F, -0.25F, -0.3F);
 	}
 
 	/**
 	 * Translates the rendering context to the center of the player's chest/torso segment
 	 */
-	static void translateToChest(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+	static void translateToChest(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
 
 		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
-			matrixStack.translate(0.0F, 0.2F, 0.0F);
-			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.torso.pitch * 57.5F));
+			matrices.translate(0.0F, 0.2F, 0.0F);
+			matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.torso.pitch * MAGIC_ROTATION));
 		}
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
-		matrixStack.translate(0.0F, 0.4F, -0.16F);
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * MAGIC_ROTATION));
+		matrices.translate(0.0F, 0.4F, -0.16F);
 	}
 
 	/**
 	 * Translates the rendering context to the center of the bottom of the player's right arm
 	 */
-	static void translateToRightArm(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+	static void translateToRightArm(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
 
 		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
-			matrixStack.translate(0.0F, 0.2F, 0.0F);
+			matrices.translate(0.0F, 0.2F, 0.0F);
 		}
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
-		matrixStack.translate(-0.3125F, 0.15625F, 0.0F);
-		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightArm.roll * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightArm.yaw * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightArm.pitch * 57.5F));
-		matrixStack.translate(-0.0625F, 0.625F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * MAGIC_ROTATION));
+		matrices.translate(-0.3125F, 0.15625F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightArm.roll * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightArm.yaw * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightArm.pitch * MAGIC_ROTATION));
+		matrices.translate(-0.0625F, 0.625F, 0.0F);
 	}
 
 	/**
 	 * Translates the rendering context to the center of the bottom of the player's left arm
 	 */
-	static void translateToLeftArm(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+	static void translateToLeftArm(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
 
 		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
-			matrixStack.translate(0.0F, 0.2F, 0.0F);
+			matrices.translate(0.0F, 0.2F, 0.0F);
 		}
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
-		matrixStack.translate(0.3125F, 0.15625F, 0.0F);
-		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftArm.roll * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftArm.yaw * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftArm.pitch * 57.5F));
-		matrixStack.translate(0.0625F, 0.625F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * MAGIC_ROTATION));
+		matrices.translate(0.3125F, 0.15625F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftArm.roll * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftArm.yaw * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftArm.pitch * MAGIC_ROTATION));
+		matrices.translate(0.0625F, 0.625F, 0.0F);
 	}
 
 	/**
 	 * Translates the rendering context to the center of the bottom of the player's right leg
 	 */
-	static void translateToRightLeg(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+	static void translateToRightLeg(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
 
 		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
-			matrixStack.translate(0.0F, 0.0F, 0.25F);
+			matrices.translate(0.0F, 0.0F, 0.25F);
 		}
-		matrixStack.translate(-0.125F, 0.75F, 0.0F);
-		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightLeg.roll * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightLeg.yaw * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightLeg.pitch * 57.5F));
-		matrixStack.translate(0.0F, 0.75F, 0.0F);
+		matrices.translate(-0.125F, 0.75F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightLeg.roll * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightLeg.yaw * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightLeg.pitch * MAGIC_ROTATION));
+		matrices.translate(0.0F, 0.75F, 0.0F);
 	}
 
 	/**
 	 * Translates the rendering context to the center of the bottom of the player's left leg
 	 */
-	static void translateToLeftLeg(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+	static void translateToLeftLeg(MatrixStack matrices, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
 
 		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
-			matrixStack.translate(0.0F, 0.0F, 0.25F);
+			matrices.translate(0.0F, 0.0F, 0.25F);
 		}
-		matrixStack.translate(0.125F, 0.75F, 0.0F);
-		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftLeg.roll * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftLeg.yaw * 57.5F));
-		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftLeg.pitch * 57.5F));
-		matrixStack.translate(0.0F, 0.75F, 0.0F);
+		matrices.translate(0.125F, 0.75F, 0.0F);
+		matrices.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftLeg.roll * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftLeg.yaw * MAGIC_ROTATION));
+		matrices.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftLeg.pitch * MAGIC_ROTATION));
+		matrices.translate(0.0F, 0.75F, 0.0F);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/AbstractButtonWidgetMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/AbstractButtonWidgetMixin.java
@@ -1,0 +1,39 @@
+package dev.emi.trinkets.mixin;
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import dev.emi.trinkets.TrinketsClient;
+import net.minecraft.client.gui.widget.AbstractButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+
+/**
+ * Makes buttons uninteractable while trinket groups are being interacted with
+ */
+@Mixin(AbstractButtonWidget.class)
+public class AbstractButtonWidgetMixin {
+
+	@Shadow
+	protected boolean hovered;
+	
+	@Inject(at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/widget/AbstractButtonWidget;hovered:Z",
+			opcode = Opcodes.PUTFIELD, ordinal = 0, shift = Shift.AFTER), method = "render")
+	public void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo info) {
+		if (TrinketsClient.activeGroup != null) {
+			hovered = false;
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "mouseClicked", cancellable = true)
+	public void mouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> info) {
+		if (TrinketsClient.activeGroup != null) {
+			info.setReturnValue(false);
+		}
+	}
+}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -2,25 +2,35 @@ package dev.emi.trinkets.mixin;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import com.mojang.datafixers.util.Function3;
+
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import dev.emi.trinkets.TrinketSlot;
 import dev.emi.trinkets.TrinketsClient;
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.Trinket.SlotReference;
 import dev.emi.trinkets.api.TrinketInventory;
-
+import net.fabricmc.fabric.api.util.TriState;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 
 /**
@@ -31,9 +41,13 @@ import net.minecraft.util.Pair;
 @Mixin(PlayerScreenHandler.class)
 public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
 
+	@Shadow @Final
+	private PlayerEntity owner;
+
 	// TODO store this exclusively in the screen handler and mixin an interface to get it from the screen
 	private Map<SlotGroup, Pair<Integer, Integer>> slotPos = new HashMap<SlotGroup, Pair<Integer, Integer>>();
 	public int trinketSlotStart;
+	public int trinketSlotEnd;
 
 	protected PlayerScreenHandlerMixin(ScreenHandlerType<?> type, int syncId) {
 		super(type, syncId);
@@ -88,6 +102,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
 				this.addSlot(new TrinketSlot(inv, i, pos.getLeft() + groupPos * 18, pos.getRight(), group, p.getLeft(), p.getRight(), groupPos == 0, p.getRight() == 0));
 			}
 		});
+		trinketSlotEnd = slots.size();
 	}
 
 	@Inject(at = @At("HEAD"), method = "close")
@@ -95,6 +110,56 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
 		if (player.world.isClient) {
 			TrinketsClient.activeGroup = null;
 			TrinketsClient.activeType = null;
+			TrinketsClient.quickMoveGroup = null;
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "transferSlot", cancellable = true)
+	public void transferSlot(PlayerEntity player, int index, CallbackInfoReturnable<ItemStack> info) {
+		Slot slot = slots.get(index);
+		if (slot != null && slot.hasStack()) {
+			ItemStack stack = slot.getStack();
+			if (index >= trinketSlotStart && index < trinketSlotEnd) {
+				if (!this.insertItem(stack, 9, 45, false)) {
+					info.setReturnValue(ItemStack.EMPTY);
+				} else {
+					info.setReturnValue(stack);
+				}
+			} else if (index >= 9 && index < 45) {
+				TrinketsApi.getTrinketComponent(owner).ifPresent(comp -> {
+					TrinketInventory inv = comp.getInventory();
+					for (int i = 0; i < inv.size(); i++) {
+						if (!slots.get(trinketSlotStart + i).canInsert(stack)) {
+							continue;
+						}
+						Pair<SlotType, Integer> pair = inv.posMap.get(i);
+						SlotType type = pair.getLeft();
+						SlotReference ref = new SlotReference(type, pair.getRight());
+						TriState state = TriState.DEFAULT;
+						for (Identifier id : type.getValidators()) {
+							Optional<Function3<ItemStack, SlotReference, LivingEntity, TriState>> function = TrinketsApi.getValidatorPredicator(id);
+							if (function.isPresent()) {
+								state = function.get().apply(stack, ref, owner);
+							}
+							if (state != TriState.DEFAULT) {
+								break;
+							}
+						}
+						if (state == TriState.DEFAULT) {
+							state = TrinketsApi.getQuickMovePredicate(new Identifier("trinkets", "always")).get().apply(stack, ref, owner);
+						}
+						if (this.insertItem(stack, trinketSlotStart + i, trinketSlotStart + i + 1, false)) {
+							if (owner.world.isClient) {
+								TrinketsClient.quickMoveTimer = 20;
+								TrinketsClient.quickMoveGroup = TrinketsApi.getPlayerSlots().get(type.getGroup());
+								if (ref.index > 0) {
+									TrinketsClient.quickMoveType = type;
+								}
+							}
+						}
+					}
+				});
+			}
 		}
 	}
 }

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -10,7 +10,8 @@
 	"client": [
 		"InventoryScreenMixin",
 		"HandledScreenMixin",
-		"PlayerEntityRendererMixin"
+		"PlayerEntityRendererMixin",
+		"AbstractButtonWidgetMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Updated to 1.16.4

Trinket EAMs are now handled
* The signature for getting modifiers now passes a UUID to use

Shift clicking now goes into trinket slots
* Uses the quick move predicate system
* Does the classic trinket slot group preview when a slot is shift clicked into (showing the group for 20 ticks unless another group is focused in that time)

Smaller things
* Trinket `onEquip` and `onUnequip` methods are now called, meaning every method in `Trinket` is now handled and used properly (except for `onBreak`)
* Buttons are no longer highlighted or interactable while a trinket group is open (a bug in the classic trinkets that was never actually fixed)

One final note, we're getting really close to release ready with trinkets, I would consider it very usable at this state. The biggest things that are unimplemented are locked slots and the fact that slot amounts are handled as different slots instead of expanding out vertically like we mentioned.