### PR TITLE
Add TrinketPlayerScreenHandler

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -1,0 +1,17 @@
+package dev.emi.trinkets;
+
+import dev.emi.trinkets.api.SlotGroup;
+import net.minecraft.util.Pair;
+
+/**
+ * Interface for putting methods onto the player's screen handler
+ */
+public interface TrinketPlayerScreenHandler {
+	
+	/**
+	 * Called to inform the player's slot handler that it needs to remove and readd its trinket slots to reflect new changes
+	 */
+	public void updateTrinketSlots();
+
+	public Pair<Integer, Integer> getGroupPos(SlotGroup group);
+}


### PR DESCRIPTION
Pretty simple, adds `TrinketPlayerScreenHandler`, an interface you can cast any `PlayerScreenHandler` to to get access to `updateTrinketSlots()`, this method should refresh a player's trinket slots on either the server or client. I also removed duplicate slot group position calculation code since the screen can now get that from this interface on its handler.