### PR TITLE
Slot syncing

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -9,7 +9,7 @@ import net.minecraft.util.Pair;
 public interface TrinketPlayerScreenHandler {
 	
 	/**
-	 * Called to inform the player's slot handler that it needs to remove and read its trinket slots to reflect new changes
+	 * Called to inform the player's slot handler that it needs to remove and re-add its trinket slots to reflect new changes
 	 */
 	public void updateTrinketSlots();
 

--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -9,7 +9,7 @@ import net.minecraft.util.Pair;
 public interface TrinketPlayerScreenHandler {
 	
 	/**
-	 * Called to inform the player's slot handler that it needs to remove and readd its trinket slots to reflect new changes
+	 * Called to inform the player's slot handler that it needs to remove and read its trinket slots to reflect new changes
 	 */
 	public void updateTrinketSlots();
 

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -2,7 +2,19 @@ package dev.emi.trinkets;
 
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.data.EntitySlotLoader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 public class TrinketsClient implements ClientModInitializer {
 	public static SlotGroup activeGroup = null;
@@ -13,6 +25,38 @@ public class TrinketsClient implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
+		ClientSidePacketRegistry.INSTANCE.register(TrinketsNetwork.SYNC_SLOTS, (packetContext, attachedData) -> {
+			CompoundTag data = attachedData.readCompoundTag();
 
+			if (data != null) {
+				Map<EntityType<?>, Map<String, SlotGroup>> slots = new HashMap<>();
+				for (String id : data.getKeys()) {
+					Optional<EntityType<?>> maybeType = Registry.ENTITY_TYPE.getOrEmpty(Identifier.tryParse(id));
+					maybeType.ifPresent(type -> {
+						CompoundTag groups = data.getCompound(id);
+
+						if (groups != null) {
+
+							for (String groupId : groups.getKeys()) {
+								CompoundTag group = groups.getCompound(groupId);
+
+								if (group != null) {
+									SlotGroup slotGroup = SlotGroup.read(group);
+									slots.computeIfAbsent(type, (k) -> new HashMap<>()).put(groupId, slotGroup);
+								}
+							}
+						}
+					});
+				}
+				packetContext.getTaskQueue().execute(() -> {
+					EntitySlotLoader.INSTANCE.setSlots(slots);
+					ClientPlayerEntity playerEntity = MinecraftClient.getInstance().player;
+
+					if (playerEntity != null) {
+						((TrinketPlayerScreenHandler) playerEntity.playerScreenHandler).updateTrinketSlots();
+					}
+				});
+			}
+		});
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -9,6 +9,7 @@ import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.LivingEntity;
@@ -20,6 +21,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
@@ -41,6 +44,8 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register(
+			(server, serverResourceManager, success) -> EntitySlotLoader.INSTANCE.sync(server.getPlayerManager().getPlayerList()));
 		TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket() {
 
 			@Override

--- a/src/main/java/dev/emi/trinkets/TrinketsNetwork.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsNetwork.java
@@ -1,0 +1,9 @@
+package dev.emi.trinkets;
+
+import net.minecraft.util.Identifier;
+
+public class TrinketsNetwork {
+
+  public static final Identifier SYNC_SLOTS = new Identifier(TrinketsMain.MOD_ID, "sync_slots");
+
+}

--- a/src/main/java/dev/emi/trinkets/api/SlotType.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotType.java
@@ -1,7 +1,13 @@
 package dev.emi.trinkets.api;
 
 import dev.emi.trinkets.api.TrinketEnums.DropRule;
+import java.util.HashSet;
 import java.util.Set;
+import net.fabricmc.fabric.api.util.NbtType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.util.Identifier;
 
 public class SlotType {
@@ -63,5 +69,59 @@ public class SlotType {
 
 	public DropRule getDropRule() {
 		return dropRule;
+	}
+
+	public void write(CompoundTag data) {
+		CompoundTag tag = new CompoundTag();
+		tag.putString("Group", group);
+		tag.putString("Name", name);
+		tag.putInt("Order", order);
+		tag.putInt("Amount", amount);
+		tag.putInt("Locked", locked);
+		tag.putString("Icon", icon.toString());
+		ListTag quickMoveList = new ListTag();
+
+		for (Identifier id : quickMove) {
+			quickMoveList.add(StringTag.of(id.toString()));
+		}
+		tag.put("QuickMove", quickMoveList);
+
+		ListTag validatorList = new ListTag();
+
+		for (Identifier id : validators) {
+			validatorList.add(StringTag.of(id.toString()));
+		}
+		tag.put("Validators", validatorList);
+		tag.putString("DropRule", dropRule.toString());
+		data.put("SlotData", tag);
+	}
+
+	public static SlotType read(CompoundTag data) {
+		CompoundTag slotData = data.getCompound("SlotData");
+		String group = slotData.getString("Group");
+		String name = slotData.getString("Name");
+		int order = slotData.getInt("Order");
+		int amount = slotData.getInt("Amount");
+		int locked = slotData.getInt("Locked");
+		Identifier icon = new Identifier(slotData.getString("Icon"));
+		ListTag quickMoveList = slotData.getList("QuickMove", NbtType.STRING);
+		Set<Identifier> quickMove = new HashSet<>();
+
+		for (Tag tag : quickMoveList) {
+			quickMove.add(new Identifier(tag.toString()));
+		}
+		ListTag validatorList = slotData.getList("Validators", NbtType.STRING);
+		Set<Identifier> validators = new HashSet<>();
+
+		for (Tag tag : validatorList) {
+			validators.add(new Identifier(tag.toString()));
+		}
+		String dropRuleName = slotData.getString("DropRule");
+		DropRule dropRule = DropRule.DEFAULT;
+
+		if (TrinketEnums.DropRule.has(dropRuleName)) {
+			dropRule = TrinketEnums.DropRule.valueOf(dropRuleName);
+		}
+		return new SlotType(group, name, order, amount, locked, icon, quickMove, validators, dropRule);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
@@ -20,6 +20,6 @@ public class PlayerManagerMixin {
 
 	@Inject(at = @At("TAIL"), method = "onPlayerConnect")
 	public void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo cb) {
-      EntitySlotLoader.INSTANCE.sync(player);
+		EntitySlotLoader.INSTANCE.sync(player);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
@@ -1,0 +1,25 @@
+package dev.emi.trinkets.mixin;
+
+
+import dev.emi.trinkets.data.EntitySlotLoader;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Syncs slot data to player's client on login
+ *
+ * @author C4
+ */
+@Mixin(PlayerManager.class)
+public class PlayerManagerMixin {
+
+	@Inject(at = @At("TAIL"), method = "onPlayerConnect")
+	public void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo cb) {
+      EntitySlotLoader.INSTANCE.sync(player);
+	}
+}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,5 +1,6 @@
 package dev.emi.trinkets.mixin;
 
+import dev.emi.trinkets.TrinketsMain;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -98,6 +99,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 		trinketSlotStart = slots.size();
 		TrinketsApi.getTrinketComponent(owner).ifPresent(trinkets -> {
 			TrinketInventory inv = trinkets.getInventory();
+			inv.update();
 			for (int i = 0; i < inv.size(); i++) {
 				Pair<SlotType, Integer> p = inv.posMap.get(i);
 				SlotGroup group = TrinketsApi.getPlayerSlots().get(p.getLeft().getGroup());

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -5,7 +5,8 @@
 	"mixins": [
 		"PlayerScreenHandlerMixin",
 		"PlayerInventoryMixin",
-		"LivingEntityMixin"
+		"LivingEntityMixin",
+		"PlayerManagerMixin"
 	],
 	"client": [
 		"InventoryScreenMixin",


### PR DESCRIPTION
Implements slot syncing. Also fixes the bug with `/reload`.
- Adds `TrinketsNetwork` class for storing packet identifiers
- Registers the new sync packet to the client packet registry
- Adds serialization and deserialization helper methods to `SlotGroup` and `SlotType`
- Adds syncing helper methods to `EntitySlotLoader`
- Adds `PlayerManagerMixin` to hook syncs to players logging in (I don't think Fabric API has a callback for this?)
- Hooks syncing logic to the `END_DATA_PACK_RELOAD` event to fix the `/reload` issue
- Extracts and edits some of the updating logic in `TrinketInventory`, which was the cause of the slots disappearing behavior because it was still holding old references once the slots updated

I've tested with `/reload`, logging in and out, and on dedicated servers, and everything seems to check out, but I haven't tested anything beyond that.