### PR TITLE
Entity Slot Loader tweaks

### DIFF
--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -76,7 +76,14 @@ public class EntitySlotLoader extends SinglePreparationResourceReloadListener<Ma
 
 							for (JsonElement entity : entities) {
 								String name = entity.getAsString();
-								Map<String, Set<String>> slots = map.computeIfAbsent(name, (k) -> new HashMap<>());
+								String id;
+
+								if (name.startsWith("#")) {
+									id = "#" + new Identifier(name.substring(1)).toString();
+								} else {
+									id = new Identifier(name).toString();
+								}
+								Map<String, Set<String>> slots = map.computeIfAbsent(id, (k) -> new HashMap<>());
 
 								if (replace) {
 									slots.clear();

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -119,7 +119,7 @@ public class SlotLoader extends SinglePreparationResourceReloadListener<Map<Stri
 		SlotType create(String group, String name) {
 			Identifier finalIcon = new Identifier(icon);
 			Set<Identifier> finalValidators = validators.stream().map(Identifier::new).collect(Collectors.toSet());
-			Set<Identifier> finalQuickMove = validators.stream().map(Identifier::new).collect(Collectors.toSet());
+			Set<Identifier> finalQuickMove = quickMove.stream().map(Identifier::new).collect(Collectors.toSet());
 			return new SlotType(group, name, order, amount, locked, finalIcon, finalQuickMove, finalValidators, DropRule.valueOf(dropRule));
 		}
 


### PR DESCRIPTION
Fairly small PR that just polishes some of the logic.
- Refactors some internal logic in `EntitySlotLoader` to accommodate entity type tags (https://github.com/emilyalexandra/trinkets/issues/63)
  - On the subject of replacing the array implementation entirely with a single entity type or tag as proposed by the issue above, I don't see much reason to do so. It would add more tedium for consumers since they would need to copy-paste their configuration for each individual entity or create a new entity tag file solely for this purpose and I'm not sure what the benefits would be over simply allowing an array of values.
- Address some edge-case issues with loading entity types with/without namespaces. For example, loading `minecraft:player` and `player` should merge them together. This was already done before, but this PR refactors the merge to take place earlier so that loading logic such as `replace` for replacing slots will affect the appropriate slots correctly.
- Fixes a small oversight with the `quickMove` field in `SlotLoader`.