### PR TITLE
Create Hungarian localisation

### DIFF
--- a/src/main/resources/assets/trinkets/lang/hu_hu.json
+++ b/src/main/resources/assets/trinkets/lang/hu_hu.json
@@ -1,0 +1,11 @@
+{
+	"trinkets.slot.head.mask": "Maszk",
+	"trinkets.slot.chest.necklace": "Nyaklánc",
+	"trinkets.slot.chest.backpack": "Hátizsák",
+	"trinkets.slot.chest.cape": "Köpeny",
+	"trinkets.slot.legs.belt": "Öv",
+	"trinkets.slot.feet.aglet": "Cipőfűző Fémvége",
+	"trinkets.slot.hand.gloves": "Kesztyű",
+	"trinkets.slot.hand.ring": "Gyűrű",
+	"trinkets.slot.offhand.ring": "Gyűrű"
+}


### PR DESCRIPTION
This PR adds Hungarian localisation for Trinkets.

Aglet has been translated as "Cipőfűző Fémvége" which is literally "The Metal End of the Shoelace" and I can't find a better translation.

In fact, translations perfectly line up with what Google Translate will give you:

- [Mask](https://translate.google.com/?sl=en&tl=hu&text=Mask&op=translate)
- [Necklace](https://translate.google.com/?sl=en&tl=hu&text=Necklace&op=translate)
- [Backpack](https://translate.google.com/?sl=en&tl=hu&text=Backpack&op=translate)
- [Cape](https://translate.google.com/?sl=en&tl=hu&text=Cape&op=translate)
- [Belt](https://translate.google.com/?sl=en&tl=hu&text=Belt&op=translate)
- [Aglet](https://translate.google.com/?sl=en&tl=hu&text=Aglet&op=translate)
- [Gloves](https://translate.google.com/?sl=en&tl=hu&text=Gloves&op=translate)
- [Ring](https://translate.google.com/?sl=en&tl=hu&text=Ring&op=translate)
